### PR TITLE
fix typo in component-cache.md

### DIFF
--- a/docs/features/component-cache.md
+++ b/docs/features/component-cache.md
@@ -111,7 +111,7 @@ You can also provide your own cache key:
 ```vue
 <template>
   <div>
-    <RenderCacheable :cache-key="[currentLanguage, currentCurreny].join('--')">
+    <RenderCacheable :cache-key="[currentLanguage, currentCurrenсy].join('--')">
       <Navbar />
     </RenderCacheable>
   </div>


### PR DESCRIPTION
Suppose, currentCurreny is currentCurrency