### PR TITLE
[bug] fix private runtime cfg on client-side

### DIFF
--- a/src/runtime/components/RenderCacheable/index.ts
+++ b/src/runtime/components/RenderCacheable/index.ts
@@ -109,7 +109,6 @@ export default defineComponent({
     },
   },
   async setup(props) {
-    const { debug } = useRuntimeConfig().multiCache
     // Extract the contents of the default slot.
     const slots = useSlots()
     if (!slots.default) {
@@ -122,6 +121,8 @@ export default defineComponent({
     // Wrap all server-side code in an if statement so that it gets properly
     // removed from the client bundles.
     if (process.server && !props.noCache) {
+      const { debug } = useRuntimeConfig().multiCache
+
       const cacheKey = getCacheKey(props as any, first, debug)
 
       // Return if no cache key found.


### PR DESCRIPTION
![image](https://github.com/dulnan/nuxt-multi-cache/assets/33551334/68530c95-b74c-468a-8cbf-6f0b30408936)


___
btw
What do You think about using the logging level to avoid a lot of `if(debug){}` checks? 

ref:
https://github.com/vuejs/vuefire/blob/main/packages/nuxt/src/runtime/logging.ts
https://github.com/vuejs/vuefire/blob/main/packages/nuxt/src/runtime/app/plugin.server.ts
