### PR TITLE
fix serverOptions types exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
       "import": "./dist/module.mjs",
       "require": "./dist/module.cjs"
     },
-    "./dist/runtime/serverOptions": "./dist/runtime/serverOptions/index.mjs"
+    "./dist/runtime/serverOptions": {
+      "import": "./dist/runtime/serverOptions/index.mjs",
+      "types": "./dist/runtime/serverOptions/index.d.ts"
+    }
   },
   "main": "./dist/module.cjs",
   "module": "./dist/module.mjs",


### PR DESCRIPTION
Like this issue https://github.com/dulnan/nuxt-graphql-middleware/issues/22, fix types exports happen since Nuxt 3.10 with the activation of [Bundler Module Resolution](https://nuxt.com/blog/v3-10#bundler-module-resolution)