### PR TITLE
Fix broken typedef export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/module.mjs",
-      "require": "./dist/module.cjs"
+      "import": {
+        "types": "./dist/types.d.ts",
+        "default": "./dist/module.mjs"
+      },
+      "require": {
+        "types": "./dist/types.d.ts",
+        "default": "./dist/module.cjs"
+      }
     },
     "./dist/runtime/serverOptions": {
       "import": "./dist/runtime/serverOptions/index.mjs",


### PR DESCRIPTION
Fixes #43 

It seems the default `types` at `package.json` root is not taken into account when using `exports`.

I already had this issue on a private repo and just faced it with this one. The fix (maybe not the cleanest) was to specify typedefs for each export.