### PR TITLE
fix: add server plugin when any feature is enabled (#69)

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -146,10 +146,15 @@ export default defineNuxtModule<ModuleOptions>({
       })
     }
 
-    // Serves cached routes.
+    // Add the server plugin if any of the features is enabled.
+    // During local development these might all be disabled, so it's not
+    // necessary to add the plugin.
     if (
       options.route?.enabled ||
       options.cdn?.enabled ||
+      options.data?.enabled ||
+      options.component?.enabled ||
+      options.api?.enabled ||
       nuxt.options._prepare
     ) {
       addServerPlugin(resolve('./runtime/server/plugins/multiCache'))

--- a/test/cacheComponent.e2e.spec.ts
+++ b/test/cacheComponent.e2e.spec.ts
@@ -10,13 +10,13 @@ const multiCache: NuxtMultiCacheOptions = {
     enabled: true,
   },
   data: {
-    enabled: true,
+    enabled: false,
   },
   route: {
-    enabled: true,
+    enabled: false,
   },
   cdn: {
-    enabled: true,
+    enabled: false,
   },
   api: {
     enabled: true,

--- a/test/customStorageDriver.e2e.spec.ts
+++ b/test/customStorageDriver.e2e.spec.ts
@@ -5,19 +5,19 @@ import type { NuxtMultiCacheOptions } from '../src/runtime/types'
 
 const multiCache: NuxtMultiCacheOptions = {
   component: {
-    enabled: true,
+    enabled: false,
   },
   data: {
     enabled: true,
   },
   route: {
-    enabled: true,
+    enabled: false,
   },
   cdn: {
-    enabled: true,
+    enabled: false,
   },
   api: {
-    enabled: true,
+    enabled: false,
     authorization: false,
     cacheTagInvalidationDelay: 5000,
   },

--- a/test/dataCache.e2e.spec.ts
+++ b/test/dataCache.e2e.spec.ts
@@ -7,16 +7,16 @@ import purgeByKey from './__helpers__/purgeByKey'
 
 const multiCache: NuxtMultiCacheOptions = {
   component: {
-    enabled: true,
+    enabled: false,
   },
   data: {
     enabled: true,
   },
   route: {
-    enabled: true,
+    enabled: false,
   },
   cdn: {
-    enabled: true,
+    enabled: false,
   },
   api: {
     enabled: true,

--- a/test/routeCache.e2e.spec.ts
+++ b/test/routeCache.e2e.spec.ts
@@ -7,16 +7,16 @@ import purgeAll from './__helpers__/purgeAll'
 
 const multiCache: NuxtMultiCacheOptions = {
   component: {
-    enabled: true,
+    enabled: false,
   },
   data: {
-    enabled: true,
+    enabled: false,
   },
   route: {
     enabled: true,
   },
   cdn: {
-    enabled: true,
+    enabled: false,
   },
   api: {
     enabled: true,


### PR DESCRIPTION
Fixes: #69

- Adds the server plugin when any of the caches/features is enabled
- Adapts tests to only enable the features they actually test