### PR TITLE
fix: call handleRawCacheData in purgeTags event handler

### DIFF
--- a/playground-disk/pages/cachedPageFromDisk.vue
+++ b/playground-disk/pages/cachedPageFromDisk.vue
@@ -10,6 +10,6 @@ const random = useState('random_data', () => {
 })
 
 useRouteCache((helper) => {
-  helper.setCacheable()
+  helper.setCacheable().addTags(['test_tag'])
 })
 </script>

--- a/src/runtime/server/api/purgeTags.ts
+++ b/src/runtime/server/api/purgeTags.ts
@@ -3,6 +3,7 @@ import { readBody, defineEventHandler, createError } from 'h3'
 import {
   decodeComponentCacheItem,
   decodeRouteCacheItem,
+  handleRawCacheData,
 } from '../../helpers/cacheItem'
 import { useMultiCacheApp } from '../utils/useMultiCacheApp'
 import { onlyUnique } from '../../helpers/server'
@@ -94,12 +95,16 @@ export class DebouncedInvalidator {
         return (item as any).cacheTags
       }
     } else if (cacheName === 'route') {
-      const cached = await this.cacheContext?.[cacheName]?.getItemRaw(key)
+      const cached = handleRawCacheData(
+        await this.cacheContext?.[cacheName]?.getItemRaw(key),
+      )
       if (cached) {
         return decodeRouteCacheItem(cached)?.cacheTags
       }
     } else if (cacheName === 'component') {
-      const cached = await this.cacheContext?.[cacheName]?.getItemRaw(key)
+      const cached = handleRawCacheData(
+        await this.cacheContext?.[cacheName]?.getItemRaw(key),
+      )
       if (cached) {
         return decodeComponentCacheItem(cached)?.cacheTags
       }

--- a/test/__helpers__/getRouteCacheItems.ts
+++ b/test/__helpers__/getRouteCacheItems.ts
@@ -1,0 +1,7 @@
+import { $fetch } from '@nuxt/test-utils/e2e'
+
+export default function (): Promise<any> {
+  return $fetch(`/__nuxt_multi_cache/stats/route`, {
+    method: 'get',
+  })
+}

--- a/test/__helpers__/purgeTags.ts
+++ b/test/__helpers__/purgeTags.ts
@@ -1,0 +1,9 @@
+import { $fetch } from '@nuxt/test-utils/e2e'
+
+export default function purgeTags(tags: string[] | string) {
+  const body: string[] = Array.isArray(tags) ? tags : [tags]
+  return $fetch(`/__nuxt_multi_cache/purge/tags`, {
+    method: 'post',
+    body: JSON.stringify(body),
+  })
+}


### PR DESCRIPTION
Fixes #79

- Call handleRawCacheData when getting cache tags of route and component cache items