### PR TITLE
fix: check enabledForRequest when serving cached route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nuxt-multi-cache",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "@tusbar/cache-control": "^1.0.2"
@@ -1940,17 +1940,6 @@
       "integrity": "sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw==",
       "dev": true
     },
-    "node_modules/@netlify/blobs": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-8.2.0.tgz",
-      "integrity": "sha512-9djLZHBKsoKk8XCgwWSEPK9QnT8qqxEQGuYh48gFIcNLvpBKkLnHbDZuyUxmNemCfDz7h0HnMXgSPnnUVgARhg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^14.16.0 || >=16.0.0"
-      }
-    },
     "node_modules/@netlify/dev-utils": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-2.2.0.tgz",
@@ -2581,17 +2570,6 @@
         "vite": ">=6.0"
       }
     },
-    "node_modules/@nuxt/eslint/node_modules/@types/node": {
-      "version": "24.0.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz",
-      "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.8.0"
-      }
-    },
     "node_modules/@nuxt/eslint/node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -2696,14 +2674,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/@nuxt/eslint/node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/@nuxt/eslint/node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -6786,14 +6756,6 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,6 +2570,18 @@
         "vite": ">=6.0"
       }
     },
+    "node_modules/@nuxt/eslint/node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/@nuxt/eslint/node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -2674,6 +2686,15 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@nuxt/eslint/node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@nuxt/eslint/node_modules/unicorn-magic": {
       "version": "0.1.0",

--- a/src/runtime/server/handler/serveCachedRoute.ts
+++ b/src/runtime/server/handler/serveCachedRoute.ts
@@ -1,6 +1,7 @@
 import { type H3Event, getRequestURL } from 'h3'
 import { useMultiCacheApp } from '../utils/useMultiCacheApp'
 import {
+  enabledForRequest,
   encodeRouteCacheKey,
   getCacheKeyWithPrefix,
   getMultiCacheContext,
@@ -40,12 +41,19 @@ function canBeServedFromCache(
 }
 
 export async function serveCachedHandler(event: H3Event) {
-  const { state } = useMultiCacheApp()
+  const isEnabled = await enabledForRequest(event)
+
+  if (!isEnabled) {
+    return
+  }
+
   const context = getMultiCacheContext(event)
 
   if (!context?.route) {
     return
   }
+
+  const { state } = useMultiCacheApp()
 
   try {
     // Build the cache key.

--- a/test/cases/conditional-route-caching/conditionalRouteCaching.e2e.spec.ts
+++ b/test/cases/conditional-route-caching/conditionalRouteCaching.e2e.spec.ts
@@ -1,0 +1,97 @@
+import path from 'node:path'
+import { setup, createPage, useTestContext, url } from '@nuxt/test-utils/e2e'
+import { describe, test, beforeEach } from 'vitest'
+import { expect as playwrightExpect } from '@nuxt/test-utils/playwright'
+import purgeAll from '~/test/__helpers__/purgeAll'
+import getRouteCacheItems from '~/test/__helpers__/getRouteCacheItems'
+import { createPageWithoutHydration } from '~/test/__helpers__'
+
+await setup({
+  server: true,
+  logLevel: 0,
+  runner: 'vitest',
+  build: true,
+  rootDir: path.resolve(__dirname, './nuxt'),
+})
+
+async function assertRouteCacheItemsLength(
+  length: number,
+  message: string,
+): Promise<void> {
+  const routeItems = await getRouteCacheItems()
+  playwrightExpect(routeItems, message).toHaveLength(length)
+}
+
+describe('Conditional route caching', () => {
+  beforeEach(async () => {
+    await purgeAll()
+  })
+
+  test('is serving from cache without a cookie', async () => {
+    await assertRouteCacheItemsLength(0, 'No items initially')
+    const page = await createPageWithoutHydration('/', 'en')
+    const value1 = await page.locator('#time').innerText()
+    await assertRouteCacheItemsLength(
+      1,
+      'One item because first request was cached',
+    )
+    await page.reload()
+    const value2 = await page.locator('#time').innerText()
+
+    playwrightExpect(
+      value1,
+      'Should be the same because served from cache.',
+    ).toEqual(value2)
+
+    await assertRouteCacheItemsLength(1, 'Still one item')
+  }, 10_000)
+
+  test('is not serving from cache with a cookie', async () => {
+    await assertRouteCacheItemsLength(0, 'No items initially')
+    const page = await createPage('/')
+    const value1 = await page.locator('#time').innerText()
+    await assertRouteCacheItemsLength(
+      1,
+      'One item because first request was cached without cookie',
+    )
+    await page.locator('#login').click()
+    await page.reload()
+
+    const value2 = await page.locator('#time').innerText()
+
+    playwrightExpect(
+      value1,
+      'Should not be the same because not served from cache.',
+    ).not.toEqual(value2)
+    await assertRouteCacheItemsLength(1, 'Still only one item')
+  }, 10_000)
+
+  test('is not serving from nor storing in cache when a cookie is already present', async () => {
+    const ctx = useTestContext()
+    const page = await createPage(undefined, {
+      javaScriptEnabled: false,
+    })
+    await assertRouteCacheItemsLength(0, 'No items initially')
+    const context = page.context()
+    const randomCookie = Math.round(Math.random() * 9999999999).toString()
+    await context.addCookies([
+      {
+        name: 'COOKIE_KEY_SESSION_TOKEN',
+        value: randomCookie,
+        url: ctx.url,
+      },
+    ])
+    await page.goto(url('/'))
+
+    const cookieValue = await page.locator('#cookie').innerText()
+
+    playwrightExpect(
+      cookieValue,
+      'Can contain cookie value because it was SSR rendered as such',
+    ).toEqual(randomCookie)
+    await assertRouteCacheItemsLength(
+      0,
+      'Still zero items because none were cached.',
+    )
+  }, 10_000)
+})

--- a/test/cases/conditional-route-caching/nuxt/app.vue
+++ b/test/cases/conditional-route-caching/nuxt/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/test/cases/conditional-route-caching/nuxt/nuxt.config.ts
+++ b/test/cases/conditional-route-caching/nuxt/nuxt.config.ts
@@ -1,0 +1,20 @@
+import { defineNuxtConfig } from 'nuxt/config'
+import NuxtMultiCache from './../../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [NuxtMultiCache],
+
+  multiCache: {
+    debug: true,
+    route: {
+      enabled: true,
+    },
+    api: {
+      enabled: true,
+      cacheTagInvalidationDelay: 5000,
+      authorization: false,
+    },
+  },
+
+  compatibilityDate: '2025-04-27',
+})

--- a/test/cases/conditional-route-caching/nuxt/pages/index.vue
+++ b/test/cases/conditional-route-caching/nuxt/pages/index.vue
@@ -1,0 +1,32 @@
+<template>
+  <div id="time">{{ time }}</div>
+  <div id="cookie">{{ cookie }}</div>
+  <button type="button" id="login" @click="login">Login</button>
+  <button type="button" id="logout" @click="logout">Logout</button>
+</template>
+
+<script setup lang="ts">
+import { useState, useRouteCache, useCookie } from '#imports'
+
+const time = useState('currentTime', () => {
+  return new Date().toISOString()
+})
+
+useRouteCache((helper) => {
+  helper
+    .setMaxAge('10m')
+    .setStaleIfError('10m')
+    .allowStaleWhileRevalidate()
+    .setCacheable()
+})
+
+const cookie = useCookie('COOKIE_KEY_SESSION_TOKEN')
+
+function login() {
+  cookie.value = 'my session'
+}
+
+function logout() {
+  cookie.value = ''
+}
+</script>

--- a/test/cases/conditional-route-caching/nuxt/server/multiCache.serverOptions.ts
+++ b/test/cases/conditional-route-caching/nuxt/server/multiCache.serverOptions.ts
@@ -1,0 +1,22 @@
+import { defineMultiCacheOptions } from './../../../../../src/server-options'
+import { getCookie } from 'h3'
+
+export default defineMultiCacheOptions(() => {
+  return {
+    route: {
+      alterCachedHeaders(headers) {
+        headers['x-cache'] = 'HIT'
+        headers['set-cookie'] = undefined
+        return headers
+      },
+    },
+
+    enabledForRequest: function (event) {
+      if (getCookie(event, 'COOKIE_KEY_SESSION_TOKEN')) {
+        return Promise.resolve(false)
+      }
+
+      return Promise.resolve(true)
+    },
+  }
+})

--- a/test/server/handler/serveCachedRoute.nuxt.spec.ts
+++ b/test/server/handler/serveCachedRoute.nuxt.spec.ts
@@ -19,6 +19,16 @@ mockNuxtImport('useRuntimeConfig', () => {
   }
 })
 
+vi.mock('#nuxt-multi-cache/config', () => {
+  return {
+    isServer: true,
+    debug: false,
+    cdnEnabled: true,
+    cdnCacheControlHeader: 'Surrogate-Control',
+    cdnCacheTagHeader: 'Cache-Tag',
+  }
+})
+
 vi.mock('#nuxt-multi-cache/server-options', () => {
   return {
     serverOptions: {},
@@ -74,6 +84,9 @@ describe('serveCachedRoute event handler', () => {
         },
       },
       context: {
+        multiCache: {
+          enabledForRequest: true,
+        },
         [MULTI_CACHE_CONTEXT_KEY]: {
           cache: {
             route: {
@@ -110,6 +123,23 @@ describe('serveCachedRoute event handler', () => {
         "x-custom-header": "test",
       }
     `)
+    mocks.useNitroApp.mockRestore()
+  })
+
+  test('Does not return a route from cache if not enabled.', async () => {
+    const event = {
+      path: '/',
+      headers: {},
+      context: {
+        multiCache: {
+          enabledForRequest: false,
+        },
+      },
+    }
+
+    const result = await serveCachedHandler(event as any)
+
+    expect(result).toBeUndefined()
     mocks.useNitroApp.mockRestore()
   })
 


### PR DESCRIPTION
Resolves #106 

This fixes a bug where `enabledForRequest` was not called when serving cached routes, which could cause hydration errors if the app depends on cookies or other request headers.