### PR TITLE
feat: provide addCustomDirective as a CDNHelper func

### DIFF
--- a/docs/composables/useCDNHeaders.md
+++ b/docs/composables/useCDNHeaders.md
@@ -124,3 +124,27 @@ const { data } = await useAsyncData(() => {
 ### mergeCacheControlHeader(header: string)
 
 Parses and merges the given `Cache-Control` header value.
+
+### addCustomDirective(name: string, value?: string | number | true)
+
+Adds a custom directive to the `Cache-Control` header that is not part of the
+standard specification. Some CDN providers support proprietary directives — for
+example Netlify's `durable` directive.
+
+Pass `true` (the default) for a valueless boolean directive, or a `string` /
+`number` for a directive with a value.
+
+```typescript
+useCDNHeaders((helper) => {
+  helper
+    .public()
+    .setNumeric('maxAge', 3600)
+    // boolean (valueless) directive
+    .addCustomDirective('durable')
+    // directive with a value
+    .addCustomDirective('cdn-ttl', 7200)
+})
+```
+
+This would produce a `Cache-Control` header like:
+`public, max-age=3600, durable, cdn-ttl=7200`

--- a/src/runtime/helpers/CDNHelper.ts
+++ b/src/runtime/helpers/CDNHelper.ts
@@ -44,6 +44,7 @@ type CacheControlBooleanProperties = keyof Pick<
 export class NuxtMultiCacheCDNHelper implements CacheabilityInterface {
   _tags: string[]
   _control: CacheControl
+  _customDirectives: Map<string, string | number | true>
   constructor(
     private readonly now: number,
     public readonly cacheControlHeader = cdnCacheControlHeader,
@@ -51,6 +52,7 @@ export class NuxtMultiCacheCDNHelper implements CacheabilityInterface {
   ) {
     this._tags = []
     this._control = new CacheControl()
+    this._customDirectives = new Map()
   }
 
   /**
@@ -67,7 +69,15 @@ export class NuxtMultiCacheCDNHelper implements CacheabilityInterface {
       setResponseHeader(event, this.cacheTagsHeader, cacheTagsValue)
     }
 
-    const cacheControlValue = this._control.format()
+    const parts: string[] = []
+    const standardValue = this._control.format()
+    if (standardValue) {
+      parts.push(standardValue)
+    }
+    for (const [name, value] of this._customDirectives) {
+      parts.push(value === true ? name : `${name}=${value}`)
+    }
+    const cacheControlValue = parts.join(', ')
     if (cacheControlValue) {
       setResponseHeader(event, this.cacheControlHeader, cacheControlValue)
     }
@@ -178,6 +188,25 @@ export class NuxtMultiCacheCDNHelper implements CacheabilityInterface {
     key: T,
   ): NuxtMultiCacheCDNHelper {
     this._control[key] = true
+    return this
+  }
+
+  /**
+   * Add a custom cache-control directive that is not part of the standard
+   * Cache-Control specification. For example, some CDN providers support
+   * proprietary directives like `durable`.
+   *
+   * Pass `true` as the value for a boolean (valueless) directive, or a string
+   * or number for a directive with a value.
+   *
+   * @param name - The directive name.
+   * @param value - The directive value. Use `true` for a valueless directive.
+   */
+  public addCustomDirective(
+    name: string,
+    value: string | number | true = true,
+  ): NuxtMultiCacheCDNHelper {
+    this._customDirectives.set(name, value)
     return this
   }
 


### PR DESCRIPTION
At the moment you can only add standard directive using the useCDNHeaders helper, but there are some instances where a CDN has custom directives that are allowed to be used i.e. Netlify has a `durable` directive. This allows for a user to add custom directives to the header.